### PR TITLE
Fix space(s) while parsing unix_socket_directories, see issue #20.

### DIFF
--- a/lib/PGDSAT.pm
+++ b/lib/PGDSAT.pm
@@ -831,7 +831,7 @@ sub check_2_5
 	chomp(@perm_sock);
 	if ($perm_sock[1])
 	{
-		my @sock_dirs = split(/,/, $perm_sock[1]);
+		my @sock_dirs = split(/,\s*/, $perm_sock[1]);
 		map { s/\@//; } @sock_dirs;
 		foreach my $d (@sock_dirs)
 		{


### PR DESCRIPTION
Add handling for space(s) after a comma separating `unix_socket_directories` values.