### PR TITLE
Add --container-mode flag for running pgdsat in containers

### DIFF
--- a/pgdsat
+++ b/pgdsat
@@ -65,6 +65,7 @@ my @options = (
 	'user|U=s',
 	'help!',
 	'no-pg-version-check!',
+	'container-mode!',
 	'remove|r=s@',
 );
 my %cfg = ();
@@ -96,13 +97,22 @@ $cfg{format} = 'html' if (!$cfg{format});
 $cfg{title} ||= 'on ' . &get_hostname();
 
 # Verify that psql, systemctl, curl and lsblk are available from PATH
+# In container-mode, skip systemctl and lsblk checks (not available in containers)
 foreach my $c (qw/psql systemctl curl lsblk/)
 {
 	next if ($cfg{'no-pg-version-check'} && $c eq 'curl');
+	next if ($cfg{'container-mode'} && ($c eq 'systemctl' || $c eq 'lsblk'));
 	`which $c 2>/dev/null`;
 	if ($? != 0) {
 		die "FATAL: command $c is not available from environment variable \$PATH\n";
 	}
+}
+
+# In container-mode, automatically remove OS-level checks that don't apply
+if ($cfg{'container-mode'}) {
+	push @{$cfg{remove}}, '1\.3';   # systemctl is-enabled check
+	push @{$cfg{remove}}, '1\.4';   # systemctl status check
+	push @{$cfg{remove}}, '1\.14';  # lsblk encryption check
 }
 
 ####
@@ -154,6 +164,12 @@ Options:
 
     --no-pg-version-check : disable check for PostgreSQL minor versions. Useful
                      when connecting to Internet is not permitted.
+
+    --container-mode : skip checks that require OS-level commands not available
+                     in containers (systemctl, lsblk). Automatically removes
+                     checks 1.3, 1.4, and 1.14 from the report. Useful when
+                     running pgdsat in Docker, Kubernetes, or similar container
+                     environments.
 Example:
 
     pgdsat -U postgres -h localhost -d postgres -o report.html


### PR DESCRIPTION
This flag enables running pgdsat in containerized environments like Docker and Kubernetes where OS-level commands (systemctl, lsblk) are not available.

Changes:
- Add new --container-mode option
- Skip systemctl and lsblk command checks when container-mode is enabled
- Automatically remove checks 1.3, 1.4, and 1.14 from report (require systemctl/lsblk)
- Update help text with --container-mode documentation

Example usage:
  pgdsat --container-mode -U postgres -d mydb -f text --no-pg-version-check